### PR TITLE
Add WS types to filter_express output objects for KBASE-4765

### DIFF
--- a/ui/narrative/methods/expression_toolkit_filter_expression/spec.json
+++ b/ui/narrative/methods/expression_toolkit_filter_expression/spec.json
@@ -60,8 +60,8 @@
       "default_values" : [ "" ],
       "field_type" : "text",
       "text_options" : {
-        "valid_ws_types" : [ ],
-		"is_output_name": true
+        "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ],
+        "is_output_name": true
       }
     }, {
       "id" : "filtered_featureset",
@@ -71,8 +71,8 @@
       "default_values" : [ "" ],
       "field_type" : "text",
       "text_options" : {
-        "valid_ws_types" : [ ],
-		"is_output_name": true
+        "valid_ws_types" : [ "KBaseCollections.FeatureSet" ],
+        "is_output_name": true
       }
     }, {
       "id" : "p_value",


### PR DESCRIPTION
In the app 'Filter Expression Matrix', attempt to change the two output objects (filtered expression matrix and filtered feature set) from Parameters to Objects in the UI and app catalog.